### PR TITLE
chore(ci): drop Node.js 20 from build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     name: Build with ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/). 
 
 The project uses GitHub Actions for continuous integration. The CI pipeline:
 
-1. Runs on Node.js 18.x, 20.x, and 21.x
+1. Runs on Node.js 22.x and 24.x
 2. Performs the following checks:
    - Linting
    - Type checking


### PR DESCRIPTION
## Summary
- Drop Node 20.x from the CI build matrix — it went EOL on 2026-04-30 and `engines` already requires `>=22`, so testing on it was bollocks
- Fix stale README CI section that still claimed Node 18.x/20.x/21.x

## Test plan
- [ ] CI passes on the remaining 22.x and 24.x matrix entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)