### PR TITLE
fix(release): honour the `!` breaking-change marker in commit subjects

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "@commitlint/cli": "^21.0.0",
     "@commitlint/config-conventional": "^21.0.0",
     "@eslint/js": "^10.0.0",
+    "@semantic-release/changelog": "^6.0.3",
+    "@semantic-release/git": "^10.0.1",
     "@types/jest": "30.0.0",
     "@types/node": "^24.0.0",
     "@types/node-fetch": "^2.6.11",
@@ -63,6 +65,7 @@
     "@typescript-eslint/parser": "8.67.0",
     "@vitest/coverage-v8": "^4.0.0",
     "commitizen": "^4.3.0",
+    "conventional-changelog-conventionalcommits": "^10.0.0",
     "cz-conventional-changelog": "^3.3.0",
     "dotenv": "^17.0.0",
     "eslint": "10.8.1",
@@ -72,13 +75,11 @@
     "node-fetch": "^3.0.0",
     "prettier": "3.9.6",
     "publint": "^0.3.15",
+    "semantic-release": "^25.0.0",
     "tsdown": "^0.22.0",
     "typescript": "6.0.3",
     "typescript-eslint": "^8.0.0",
-    "vitest": "^4.0.0",
-    "@semantic-release/changelog": "^6.0.3",
-    "@semantic-release/git": "^10.0.1",
-    "semantic-release": "^25.0.0"
+    "vitest": "^4.0.0"
   },
   "dependencies": {
     "change-case": "^5.4.4",
@@ -97,8 +98,18 @@
       "main"
     ],
     "plugins": [
-      "@semantic-release/commit-analyzer",
-      "@semantic-release/release-notes-generator",
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "preset": "conventionalcommits"
+        }
+      ],
+      [
+        "@semantic-release/release-notes-generator",
+        {
+          "preset": "conventionalcommits"
+        }
+      ],
       "@semantic-release/changelog",
       [
         "@semantic-release/npm",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       commitizen:
         specifier: ^4.3.0
         version: 4.3.2(@types/node@24.13.3)(typescript@6.0.3)
+      conventional-changelog-conventionalcommits:
+        specifier: ^10.0.0
+        version: 10.3.0
       cz-conventional-changelog:
         specifier: ^3.3.0
         version: 3.3.0(@types/node@24.13.3)(typescript@6.0.3)


### PR DESCRIPTION
## Why

#828 merged as `feat!: drop the CommonJS build and ship ESM-only` and the Release workflow ran green but published nothing:

```
[@semantic-release/commit-analyzer] Analysis of 101 commits complete: no release
There are no relevant changes, so no new version is released.
```

## Root cause

Two independent failures, either of which alone would have been survivable:

**1. The squash-merge dropped the footer.** The commit on main (`a448b66`) has a single parent and its entire body is `Co-authored-by: ...`. The `BREAKING CHANGE:` footer written on the branch commit never reached main.

**2. The default `angular` preset ignores `!`.** It has no handling for the `!` shorthand, so `feat!` is parsed as an unknown type — meaning it produced *no release at all*, not even the minor bump a plain `feat` would earn.

Running the actual `@semantic-release/commit-analyzer` plugin over the real `v1.10.0..main` range (all 101 commits):

| preset | release type |
|---|---|
| `angular` (current) | **NONE** — matches CI exactly |
| `conventionalcommits` | **major** |

## Fix

Switch commit-analyzer and release-notes-generator to the `conventionalcommits` preset. In a squash-merge workflow the subject line is the only part reliably preserved, so the breaking-change signal needs to live there — which is precisely what `!` is for.

Per-type classification is unchanged; the preset only adds `!` support:

| commit | angular | conventionalcommits |
|---|---|---|
| `feat!: …` | NONE | **major** |
| `feat: …` | minor | minor |
| `fix: …` | patch | patch |
| `chore(deps): …` | none | none |

`conventional-changelog-conventionalcommits` is added as an explicit devDependency. It is **not** a dependency of either plugin — it resolved locally only through incidental pnpm hoisting, which a clean CI install would not guarantee. Declaring it is what makes the fix hold in CI.

## Effect on merge

No manual re-tag needed. semantic-release re-analyses everything since `v1.10.0` on each run, so once this lands, the existing `feat!` commit is re-read as breaking and **2.0.0** publishes on the next Release run.

## Notes

- Sorting devDependencies moved three entries (`@semantic-release/*`, `semantic-release`) that were previously appended out of order — cosmetic, from writing the file back programmatically.
- Full check suite re-run: lint clean, types clean, 184 tests passing, `attw` + `publint` green, package smoke test passing.
- The full `semantic-release --dry-run` could not be run locally — semantic-release requires Node `^22.14 || >=24.10` and this machine has 24.4.0. CI's `24.x` satisfies it. The analyzer evidence above was gathered by invoking the plugin directly against real git history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
